### PR TITLE
clarify that this plugin doesnt support leaflet 1.1.0 yet

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ legend data([see format](http://resources.arcgis.com/en/help/arcgis-rest-api/ind
 **The legend task for mapservers is ready & tested, feature layers part is developed
 separately and will be released later**
 
-### [Example](https://w8r.github.io/esri-leaflet-legend/example/)
+### [Example](https://w8r.github.io/esri-leaflet-legend/example/) (Leaflet `1.0.x`)
 
-* [Example with feature layers](https://w8r.github.io/esri-leaflet-legend/example/featureserver.html)
+* [Example with feature layers](https://w8r.github.io/esri-leaflet-legend/example/featureserver.html) (Leaflet `0.7.x`)
 
 ```js
 var map = L.map('map', {maxZoom: 20}).setView([ 41.78408507289525, -88.13716292381285], 18);
@@ -102,5 +102,5 @@ Make sure you have the [Grunt CLI](http://gruntjs.com/getting-started) installed
 
 ### Licensing
 
-MIT
+[MIT](LICENSE)
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/w8r/esri-leaflet-legend#readme",
   "dependencies": {
     "esri-leaflet": "^2.0.6",
-    "leaflet": "^1.0.2"
+    "leaflet": "~1.0.2"
   },
   "devDependencies": {
     "assemble": "^0.17.1",


### PR DESCRIPTION
partially addresses #5 

* capped Leaflet dependency in package.json at 1.0.x ([more info](https://stackoverflow.com/questions/22343224/whats-the-difference-between-tilde-and-caret-in-package-json))
* added MIT LICENSE
* clarified in README that one sample is leaflet 0.7.x and the other is 1.0.x

additional recommendations
* `gh-pages` isn't in sync with `master`, so both of your live samples currently load leaflet 0.7.x.  i'd recommend deleting that branch entirely and configuring the repo to use `master` to host your static pages ([more info](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/))
* the inclusion of both plain and 'compat' builds is pretty confusing. if you really need both, it'd be helpful if you explained why in your doc